### PR TITLE
Fix silent pagefile failure + add optional Intune remediation for fleet deployment

### DIFF
--- a/Intune/Detection.ps1
+++ b/Intune/Detection.ps1
@@ -6,7 +6,7 @@ re-tester individuellement les ~150 services : plus rapide, et evite de reprodui
 fragilite du script d'origine sur des controles repetes a chaque cycle de detection.
 #>
 
-$ScriptVersion = '1.1.0'
+$ScriptVersion = '1.2.0'
 $MarkerPath    = 'HKLM:\SOFTWARE\TBOK-Optimizer'
 
 try {

--- a/Intune/Detection.ps1
+++ b/Intune/Detection.ps1
@@ -1,0 +1,35 @@
+<#
+Intune Proactive Remediation - Detection.
+Exit 0 = conforme (rien a faire). Exit 1 = non conforme (declenche Remediation.ps1).
+Verifie un marqueur de version + une derive concrete (taille du pagefile) plutot que de
+re-tester individuellement les ~150 services : plus rapide, et evite de reproduire la
+fragilite du script d'origine sur des controles repetes a chaque cycle de detection.
+#>
+
+$ScriptVersion = '1.0.0'
+$MarkerPath    = 'HKLM:\SOFTWARE\TBOK-Optimizer'
+
+try {
+    $marker = Get-ItemProperty -Path $MarkerPath -ErrorAction Stop
+    $versionMatches = $marker.AppliedVersion -eq $ScriptVersion
+
+    $pfExpectedOk = $true
+    $ramMB = [Math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1MB, 0)
+    if ($ramMB -lt 32768) {
+        $min = 4096
+        $max = if ($ramMB -lt 8192) { 8192 } elseif ($ramMB -lt 16384) { 16384 } else { 24576 }
+        $pf = Get-WmiObject Win32_PageFileSetting -Filter "Name='C:\\pagefile.sys'" -ErrorAction SilentlyContinue
+        $pfExpectedOk = [bool]($pf -and $pf.InitialSize -eq $min -and $pf.MaximumSize -eq $max)
+    }
+
+    if ($versionMatches -and $pfExpectedOk) {
+        Write-Output "Compliant: optimizer v$ScriptVersion applied, pagefile sizing correct."
+        exit 0
+    } else {
+        Write-Output "Non-compliant: versionMatches=$versionMatches pagefileOk=$pfExpectedOk"
+        exit 1
+    }
+} catch {
+    Write-Output "Non-compliant: marker not found -- $($_.Exception.Message)"
+    exit 1
+}

--- a/Intune/Detection.ps1
+++ b/Intune/Detection.ps1
@@ -6,7 +6,7 @@ re-tester individuellement les ~150 services : plus rapide, et evite de reprodui
 fragilite du script d'origine sur des controles repetes a chaque cycle de detection.
 #>
 
-$ScriptVersion = '1.0.0'
+$ScriptVersion = '1.1.0'
 $MarkerPath    = 'HKLM:\SOFTWARE\TBOK-Optimizer'
 
 try {

--- a/Intune/README.md
+++ b/Intune/README.md
@@ -1,0 +1,62 @@
+# TBOK Optimizer for Intune (Proactive Remediations)
+
+A headless, business-fleet-friendly port of the ideas in `TBOKwinOptimizer.bat`, meant to
+run unattended as a Microsoft Intune Proactive Remediation instead of interactively on a
+single PC.
+
+It does **not** replace the `.bat` script - that one is still the right tool for a single
+personal/gaming PC you run by hand. This is for pushing a safe subset of the same tweaks
+across a managed fleet.
+
+## Why a separate script instead of just running the .bat via Intune
+
+The `.bat` script assumes an interactive session: it self-elevates via UAC, shows a
+`CHOICE` menu, and prompts to reboot at the end. None of that works under Intune, which
+runs scripts headlessly (as SYSTEM by default) with no user to answer prompts - a
+prompt like the final Y/N reboot question would just hang forever. `Remediation.ps1` is a
+rewrite of the safe/relevant subset of the tweaks with no interactive steps, no forced
+reboot (see below), and idempotent PowerShell instead of one-shot batch calls.
+
+## Files
+
+- **Detection.ps1** - exit `0` if the target state is already applied, `1` otherwise.
+  Checks a version marker plus one concrete drift check (pagefile sizing) rather than
+  re-verifying every single service, so it stays fast on every Intune detection cycle.
+- **Remediation.ps1** - applies the tweaks. Runs only when Detection.ps1 exits `1`.
+
+## Setup in Intune
+
+Devices and monitoring > Scripts and remediations > Create:
+- Detection script file: `Detection.ps1`
+- Remediation script file: `Remediation.ps1`
+- Run this script using the logged-on credentials: **No** (runs as SYSTEM)
+- Enforce script signature check: per your org's policy
+- Run script in 64-bit PowerShell host: **Yes**
+
+## What's different from the .bat script, on purpose
+
+- **No forced reboot.** The original prompts "Restart now? [Y/N]" at the end, which is
+  fine on your own PC but not on a fleet. `Remediation.ps1` instead writes
+  `HKLM:\SOFTWARE\TBOK-Optimizer\PendingReboot` (`1`/`0`) so you can react to it via your
+  own reporting/compliance policy instead of rebooting unattended machines mid-workday.
+- **Pagefile bug fix.** `Set-CimInstance` against `Win32_PageFileSetting` throws
+  `Value out of range` on a number of builds (a known CIM provider quirk with that class -
+  it round-trips read-only properties on write). It's a non-terminating error, so the
+  original script's `try/catch` never catches it and logs a false "Configured pagefile"
+  success even when nothing changed. `Remediation.ps1` uses the `Get-WmiObject`/`.Put()`
+  path instead, which doesn't have this problem (same fix proposed for the `.bat` script
+  itself in this PR).
+- **Conservative defaults for a managed fleet**, toggled via the `$Config` block at the
+  top of `Remediation.ps1`:
+  - Telemetry is split into individual toggles instead of one on/off switch. The
+    cosmetic ones (feedback popups, advertising ID, Recall, limiting enhanced diagnostic
+    data) are on by default. The ones that can degrade Defender for Endpoint / Update
+    Compliance / Windows Update for Business reporting (lowering the telemetry level,
+    disabling the DiagTrack service, disabling WER, disabling Delivery Optimization) are
+    off by default - flip them only after checking with whoever owns security/infra
+    reporting for the fleet.
+  - No Windows Copilot removal - out of scope for orgs using Microsoft 365 Copilot
+    (a separate product from the OS-level consumer Copilot), and not something every org
+    will want touched centrally.
+  - Legacy F8 boot menu, gaming tweaks (except HAGS) and consumer-feature/ad removal are
+    off by default - see the comments next to each flag in `Remediation.ps1`.

--- a/Intune/Remediation.ps1
+++ b/Intune/Remediation.ps1
@@ -1,0 +1,397 @@
+#Requires -RunAsAdministrator
+<#
+Intune Proactive Remediation - portage du script batch "TBOK Windows Performance Optimizer".
+Profil de defaut : parc d'entreprise (bureautique). Bascule les $Config ci-dessous pour
+activer les sections desactivees par defaut (telemetrie, boot legacy, gaming).
+Pas de section retrait Copilot : l'org utilise Copilot 365 (M365 Copilot dans les apps
+Office), independant du Copilot consumer integre a l'OS - rien a nettoyer ici.
+Intune : configurer "Run this script using the logged-on credentials" = No (execution SYSTEM),
+"Enforce script signature check" selon ta politique, 64-bit PowerShell = Yes.
+#>
+
+$ScriptVersion = '1.1.0'
+$MarkerPath    = 'HKLM:\SOFTWARE\TBOK-Optimizer'
+$LogDir        = "$env:ProgramData\TBOK-Optimizer"
+$LogFile       = Join-Path $LogDir 'remediation.log'
+
+$Config = @{
+    CreateRestorePoint        = $true
+    ApplyPerformanceTweaks    = $true    # pagefile, network throttling, IRPStackSize, SvcHostSplit, shutdown timeout, long paths
+    ApplyServiceStartupTweaks = $true    # listes demand/auto/delayed-auto ci-dessous
+    ConfigureHibernation      = $true    # desktop -> off, laptop -> on, chassis indetermine -> on ne touche a rien
+    DisableSshAgentService    = $false   # laisse a false si des postes dev sont dans le groupe cible
+    DisableConsumerFeatures   = $false   # pubs Start/Explorer, suggestions - cosmetique, pas lie a la telemetrie
+    SetLegacyBootMenu         = $false   # bcdedit F8 legacy - modifie le comportement de recuperation BitLocker
+    ApplyGamingTweaks         = $false   # HAGS seulement (le plan Ultimate Performance / lock P-state GPU ne sont pas portes)
+    ApplyUserPreferenceTweaks = $true    # prefs Explorer par profil (This PC par defaut, End Task, menu contextuel complet)
+}
+
+# Telemetrie : toggles individuels plutot qu'un flag global "tout ou rien".
+# - Les 4 premiers sont purement cosmetiques (pubs/suggestions/feedback), zero impact outillage.
+# - Les 4 suivants sont desactives par defaut : ils peuvent degrader Defender for Endpoint,
+#   Update Compliance / Windows Update for Business, ou la capacite de support interne
+#   (dumps locaux). A activer seulement apres validation avec l'equipe securite/infra.
+$Config.Telemetry = @{
+    DisableFeedbackNotifications = $true    # popups "notez cette app" - cosmetique
+    DisableAdvertisingId         = $true    # pub personnalisee - cosmetique
+    LimitEnhancedDiagnosticData  = $true    # recommande par Microsoft pour les orgs utilisant Desktop/Endpoint Analytics
+    DisableRecall                = $true    # durcissement securite largement recommande, indep. de la telemetrie generale
+    LowerTelemetryLevel          = $false   # AllowTelemetry=0 (Security) -- peut degrader Defender for Endpoint / Update Compliance
+    DisableDiagTrackService      = $false   # coupe TOUTE remontee de diagnostic -- meme risque que ci-dessus
+    DisableWindowsErrorReporting = $false   # reduit la capacite de support interne (dumps locaux)
+    DisableDeliveryOptimization  = $false   # pas de la telemetrie : impacte le P2P de distribution des mises a jour sur le LAN, generalement deconseille sur un parc
+}
+
+New-Item -Path $LogDir -ItemType Directory -Force | Out-Null
+
+function Write-Log {
+    param([string]$Message)
+    $line = "[{0}] {1}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $Message
+    Add-Content -Path $LogFile -Value $line
+}
+
+function Invoke-Safely {
+    param([string]$Description, [scriptblock]$Action)
+    try {
+        & $Action
+        Write-Log "OK: $Description"
+        return $true
+    } catch {
+        Write-Log "FAILED: $Description -- $($_.Exception.Message)"
+        return $false
+    }
+}
+
+function Set-ServiceStartupSafely {
+    param(
+        [string]$Name,
+        [ValidateSet('Automatic', 'Manual', 'Disabled', 'DelayedAutomatic')]
+        [string]$StartupType
+    )
+    $services = Get-Service -Name $Name -ErrorAction SilentlyContinue
+    if (-not $services) { return }
+    foreach ($svc in $services) {
+        try {
+            if ($StartupType -eq 'DelayedAutomatic') {
+                $null = sc.exe config $svc.Name start= delayed-auto
+                if ($LASTEXITCODE -ne 0) { throw "sc.exe exited $LASTEXITCODE" }
+            } else {
+                Set-Service -Name $svc.Name -StartupType $StartupType -ErrorAction Stop
+            }
+            Write-Log "OK: service $($svc.Name) -> $StartupType"
+        } catch {
+            Write-Log "FAILED: service $($svc.Name) -> $StartupType -- $($_.Exception.Message)"
+        }
+    }
+}
+
+$RebootRequired = $false
+Write-Log "=== Remediation started (v$ScriptVersion) ==="
+
+# --- Point de restauration (avec repli backup registre si echec) ---
+if ($Config.CreateRestorePoint) {
+    Invoke-Safely "Enable System Restore on system drive" {
+        Enable-ComputerRestore -Drive $env:SystemDrive -ErrorAction Stop
+    }
+    Invoke-Safely "Ensure VSS service is running" {
+        if ((Get-Service -Name VSS).Status -ne 'Running') { Start-Service VSS -ErrorAction Stop }
+    }
+    Invoke-Safely "Allow immediate restore point creation" {
+        New-ItemProperty -Path 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\SystemRestore' `
+            -Name SystemRestorePointCreationFrequency -PropertyType DWord -Value 0 -Force -ErrorAction Stop | Out-Null
+    }
+    $rpOk = Invoke-Safely "Create restore point 'Before Intune Optimizer Remediation'" {
+        Checkpoint-Computer -Description 'Before Intune Optimizer Remediation' -RestorePointType MODIFY_SETTINGS -ErrorAction Stop
+    }
+    if (-not $rpOk) {
+        Invoke-Safely "Fallback: export HKLM/HKCU registry backup" {
+            reg export HKLM (Join-Path $LogDir 'HKLM-backup.reg') /y | Out-Null
+            reg export HKCU (Join-Path $LogDir 'HKCU-backup.reg') /y | Out-Null
+        }
+    }
+}
+
+# --- Hibernation selon le type de chassis (repli sur "ne rien changer" si indetermine) ---
+if ($Config.ConfigureHibernation) {
+    $chassisTypes = (Get-CimInstance -ClassName Win32_SystemEnclosure -ErrorAction SilentlyContinue).ChassisTypes
+    $desktopTypes = 3, 4, 5, 6, 7, 13, 15, 16, 24
+    $laptopTypes  = 8, 9, 10, 11, 12, 14, 18, 21, 30, 31, 32
+    if ($chassisTypes | Where-Object { $_ -in $desktopTypes }) {
+        Invoke-Safely "Disable hibernation (desktop, chassis=$($chassisTypes -join ','))" { powercfg -h off }
+    } elseif ($chassisTypes | Where-Object { $_ -in $laptopTypes }) {
+        Invoke-Safely "Enable hibernation (laptop, chassis=$($chassisTypes -join ','))" { powercfg -h on }
+    } else {
+        Write-Log "SKIPPED: chassis type undetermined (raw=$($chassisTypes -join ',')) - hibernation left unchanged"
+    }
+}
+
+# --- Tweaks de performance ---
+if ($Config.ApplyPerformanceTweaks) {
+
+    Invoke-Safely "Disable network throttling" {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile' `
+            -Name NetworkThrottlingIndex -PropertyType DWord -Value 0xffffffff -Force | Out-Null
+    }
+    Invoke-Safely "Set SystemResponsiveness to 10" {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile' `
+            -Name SystemResponsiveness -PropertyType DWord -Value 10 -Force | Out-Null
+    }
+    Invoke-Safely "Speed up service shutdown timeout" {
+        New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control' `
+            -Name WaitToKillServiceTimeout -PropertyType String -Value '5000' -Force | Out-Null
+    }
+    Invoke-Safely "Enable long path support" {
+        New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' `
+            -Name LongPathsEnabled -PropertyType DWord -Value 1 -Force | Out-Null
+    }
+    Invoke-Safely "Set SvcHost split threshold to installed RAM" {
+        $memKB = (Get-CimInstance Win32_PhysicalMemory | Measure-Object Capacity -Sum).Sum / 1KB
+        New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control' `
+            -Name SvcHostSplitThresholdInKB -PropertyType DWord -Value ([uint32]$memKB) -Force | Out-Null
+    }
+
+    # Set-CimInstance sur Win32_PageFileSetting renvoie "Valeur hors de la plage" sur pas mal de
+    # builds (round-trip de proprietes read-only cote provider). Get-WmiObject/.Put() est le
+    # contournement documente et fiable pour cette classe WMI precise.
+    Invoke-Safely "Configure pagefile sizing" {
+        $ramMB = [Math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1MB, 0)
+        if ($ramMB -ge 32768) {
+            $cs = Get-WmiObject Win32_ComputerSystem
+            if (-not $cs.AutomaticManagedPagefile) {
+                $cs.AutomaticManagedPagefile = $true
+                $cs.Put() | Out-Null
+                $script:RebootRequired = $true
+            }
+            Write-Log "RAM=$ramMB MB >= 32GB, pagefile management set to automatic"
+        } else {
+            $min = 4096
+            $max = if ($ramMB -lt 8192) { 8192 } elseif ($ramMB -lt 16384) { 16384 } else { 24576 }
+            $cs = Get-WmiObject Win32_ComputerSystem
+            if ($cs.AutomaticManagedPagefile) {
+                $cs.AutomaticManagedPagefile = $false
+                $cs.Put() | Out-Null
+            }
+            $pf = Get-WmiObject Win32_PageFileSetting -Filter "Name='C:\\pagefile.sys'"
+            if ($pf) {
+                if ($pf.InitialSize -ne $min -or $pf.MaximumSize -ne $max) {
+                    $pf.InitialSize = $min
+                    $pf.MaximumSize = $max
+                    $pf.Put() | Out-Null
+                    $script:RebootRequired = $true
+                }
+            } else {
+                Set-WmiInstance -Class Win32_PageFileSetting -Arguments @{ Name = 'C:\pagefile.sys'; InitialSize = $min; MaximumSize = $max } | Out-Null
+                $script:RebootRequired = $true
+            }
+            Write-Log "RAM=$ramMB MB, pagefile Initial=$min MB Maximum=$max MB"
+        }
+    }
+}
+
+# --- Startup type des services ---
+if ($Config.ApplyServiceStartupTweaks) {
+
+    $disabledServices = 'AppVClient', 'NetTcpPortSharing', 'DialogBlockingService', 'UevAgentService'
+    if ($Config.Telemetry.DisableDiagTrackService) { $disabledServices += 'DiagTrack' }
+    if ($Config.DisableSshAgentService) { $disabledServices += 'ssh-agent' }
+    foreach ($s in $disabledServices) { Set-ServiceStartupSafely -Name $s -StartupType Disabled }
+
+    # SysMain : NVMe/SSD -> disabled, HDD avec >12GB RAM -> manual, HDD <=12GB -> disabled
+    Invoke-Safely "Tune SysMain for boot drive type" {
+        $ramGB = [Math]::Round((Get-CimInstance Win32_PhysicalMemory | Measure-Object Capacity -Sum).Sum / 1GB, 0)
+        $bootDisk = Get-Partition -DriveLetter $env:SystemDrive.TrimEnd(':') | Get-Disk
+        $isFastDisk = $bootDisk.BusType -eq 'NVMe' -or $bootDisk.MediaType -eq 'SSD'
+        if ($isFastDisk) {
+            Set-ServiceStartupSafely -Name SysMain -StartupType Disabled
+        } elseif ($ramGB -gt 12) {
+            Set-ServiceStartupSafely -Name SysMain -StartupType Manual
+        } else {
+            Set-ServiceStartupSafely -Name SysMain -StartupType Disabled
+        }
+    }
+
+    # Services optionnels/consommateur -> Manual. Deja exclus (comme dans le script d'origine) :
+    # NlaSvc, netprofm, TokenBroker, UsoSvc, WpnService, RemoteAccess, RemoteRegistry (sensibles entreprise).
+    $manualServices = @(
+        'ALG', 'AppIDSvc', 'AppMgmt', 'AppReadiness', 'Appinfo', 'AssignedAccessManagerSvc', 'AxInstSV', 'BDESVC',
+        'BcastDVRUserService_*', 'BluetoothUserService_*', 'BTAGService', 'bthserv', 'CaptureService_*', 'cbdhsvc_*',
+        'CertPropSvc', 'cloudidsvc', 'COMSysApp', 'ClipSVC', 'ConsentUxUserSvc_*', 'CredentialEnrollmentManagerUserSvc_*',
+        'CscService', 'DcpSvc', 'dcsvc', 'defragsvc', 'DevQueryBroker', 'DeviceAssociationBroker_*', 'DeviceAssociationService',
+        'DeviceInstall', 'DevicePickerUserSvc_*', 'DevicesFlowUserSvc_*', 'diagnosticshub.standardcollector.service',
+        'diagsvc', 'DisplayEnhancementService', 'DmEnrollmentSvc', 'dmwappushservice', 'dot3svc', 'DoSvc', 'embeddedmode',
+        'fdPHost', 'fhsvc', 'hidserv', 'icssvc', 'EapHost', 'edgeupdate', 'edgeupdatem', 'EFS', 'EntAppSvc', 'FDResPub', 'Fax',
+        'FrameServer', 'FrameServerMonitor', 'GraphicsPerfSvc', 'HvHost', 'IEEtwCollectorService', 'IKEEXT', 'IpxlatCfgSvc',
+        'lfsvc', 'lltdsvc', 'lmhosts', 'LxpSvc', 'McpManagementService', 'MessagingService_*', 'MicrosoftEdgeElevationService',
+        'MixedRealityOpenXRSvc', 'MSDTC', 'MsKeyboardFilter', 'MSiSCSI', 'msiserver', 'NPSMSvc_*', 'NaturalAuthentication',
+        'NcaSvc', 'NcbService', 'NcdAutoSetup', 'NetSetupSvc', 'Netman', 'NgcCtnrSvc', 'NgcSvc', 'p2pimsvc', 'p2psvc',
+        'P9RdrService_*', 'PcaSvc', 'PeerDistSvc', 'PenService_*', 'perceptionsimulation', 'PerfHost', 'PhoneSvc',
+        'PimIndexMaintenanceSvc_*', 'pla', 'PlugPlay', 'PNRPAutoReg', 'PNRPsvc', 'PolicyAgent', 'PrintNotify',
+        'PrintWorkflowUserSvc_*', 'PushToInstall', 'QWAVE', 'RasAuto', 'RasMan', 'RetailDemo', 'RmSvc', 'RpcLocator',
+        'SCPolicySvc', 'ScDeviceEnum', 'SCardSvr', 'SDRSVC', 'seclogon', 'SEMgrSvc', 'SensorDataService', 'SensorService',
+        'SensrSvc', 'SessionEnv', 'SharedAccess', 'SharedRealitySvc', 'shpamsvc', 'SmsRouter', 'smphost', 'SNMPTrap',
+        'spectrum', 'SstpSvc', 'SSDPSRV', 'StiSvc', 'StorSvc', 'svsvc', 'swprv', 'TabletInputService', 'TapiSrv',
+        'TieringEngineService', 'TimeBroker', 'TimeBrokerSvc', 'TroubleshootingSvc', 'UI0Detect', 'UdkUserSvc_*',
+        'UmRdpService', 'UnistoreSvc_*', 'UserDataSvc_*', 'upnphost', 'VacSvc', 'vds', 'vmicguestinterface', 'vmicheartbeat',
+        'vmickvpexchange', 'vmicrdv', 'vmicshutdown', 'vmictimesync', 'vmicvmsession', 'vmicvss', 'VSS', 'WalletService',
+        'wbengine', 'WcsPlugInService', 'wcncsvc', 'WdNisSvc', 'WdiServiceHost', 'WdiSystemHost', 'WebClient', 'Wecsvc',
+        'wercplsupport', 'WEPHOSTSVC', 'WerSvc', 'WFDSConMgrSvc', 'WiaRpc', 'WinHttpAutoProxySvc', 'WinRM', 'wisvc',
+        'wlidsvc', 'wlpasvc', 'wmiApSrv', 'WMPNetworkSvc', 'WManSvc', 'WPDBusEnum', 'WpcMonSvc', 'workfolderssvc',
+        'XblAuthManager', 'XblGameSave', 'XboxNetApiSvc'
+    )
+    foreach ($s in $manualServices) { Set-ServiceStartupSafely -Name $s -StartupType Manual }
+
+    $autoServices = @(
+        'AudioEndpointBuilder', 'AudioSrv', 'BFE', 'BITS', 'BrokerInfrastructure', 'BthHFSrv', 'CDPUserSvc_*',
+        'CoreMessagingRegistrar', 'CryptSvc', 'DPS', 'DcomLaunch', 'Dhcp', 'DispBrokerDesktopSvc', 'Dnscache', 'dusmsvc',
+        'EventLog', 'EventSystem', 'FontCache', 'gpsvc', 'iphlpsvc', 'LSM', 'LanmanServer', 'LanmanWorkstation', 'MpsSvc',
+        'nsi', 'OneSyncSvc_*', 'Power', 'ProfSvc', 'RpcEptMapper', 'RpcSs', 'SENS', 'SamSs', 'Schedule', 'ShellHWDetection',
+        'Spooler', 'sppsvc', 'SystemEventsBroker', 'Themes', 'tiledatamodelsvc', 'TrkWks', 'tzautoupdate', 'uhssvc',
+        'UserManager', 'W32Time', 'Wcmsvc', 'WinDefend', 'Winmgmt', 'WlanSvc', 'WpnUserService_*'
+    )
+    foreach ($s in $autoServices) { Set-ServiceStartupSafely -Name $s -StartupType Automatic }
+
+    $delayedAutoServices = 'SecurityHealthService', 'WSearch', 'wscsvc', 'wuauserv', 'wudfsvc', 'XboxGipSvc'
+    foreach ($s in $delayedAutoServices) { Set-ServiceStartupSafely -Name $s -StartupType DelayedAutomatic }
+}
+
+# --- Telemetrie : items cosmetiques/sans risque appliques par defaut, items sensibles
+# (niveau global, service DiagTrack, WER, Delivery Optimization) laisses au repos ---
+if ($Config.Telemetry.DisableFeedbackNotifications) {
+    Invoke-Safely "Disable feedback notification popups" {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection' -Name DoNotShowFeedbackNotifications -PropertyType DWord -Value 1 -Force | Out-Null
+    }
+}
+if ($Config.Telemetry.DisableAdvertisingId) {
+    Invoke-Safely "Disable advertising ID (machine policy)" {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\AdvertisingInfo' -Name DisabledByGroupPolicy -PropertyType DWord -Value 1 -Force | Out-Null
+    }
+}
+if ($Config.Telemetry.LimitEnhancedDiagnosticData) {
+    Invoke-Safely "Limit enhanced diagnostic data to Desktop/Endpoint Analytics events only" {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection' -Name LimitEnhancedDiagnosticDataWindowsAnalytics -PropertyType DWord -Value 1 -Force | Out-Null
+    }
+}
+if ($Config.Telemetry.DisableRecall) {
+    Invoke-Safely "Disable Windows Recall" {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsAI' -Name AllowRecallEnablement -PropertyType DWord -Value 0 -Force | Out-Null
+    }
+}
+if ($Config.Telemetry.LowerTelemetryLevel) {
+    Invoke-Safely "Lower telemetry level to Security (0)" {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection' -Name AllowTelemetry -PropertyType DWord -Value 0 -Force | Out-Null
+    }
+}
+if ($Config.Telemetry.DisableWindowsErrorReporting) {
+    Invoke-Safely "Disable Windows Error Reporting" {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting' -Name Disabled -PropertyType DWord -Value 1 -Force | Out-Null
+    }
+}
+if ($Config.Telemetry.DisableDeliveryOptimization) {
+    Invoke-Safely "Disable Delivery Optimization (P2P update distribution)" {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization' -Name DODownloadMode -PropertyType DWord -Value 0 -Force | Out-Null
+    }
+}
+# DisableDiagTrackService est applique plus haut, dans la liste $disabledServices.
+
+# --- Menu de boot F8 legacy (off par defaut : impacte les prompts de recuperation BitLocker) ---
+if ($Config.SetLegacyBootMenu) {
+    Invoke-Safely "Enable legacy F8 boot menu" {
+        bcdedit /set '{default}' bootmenupolicy legacy | Out-Null
+        $script:RebootRequired = $true
+    }
+}
+
+# --- Gaming (seul HAGS est porte ; Ultimate Performance et lock P-state GPU volontairement exclus) ---
+if ($Config.ApplyGamingTweaks) {
+    Invoke-Safely "Enable Hardware-Accelerated GPU Scheduling" {
+        New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\GraphicsDrivers' -Name HwSchMode -PropertyType DWord -Value 2 -Force | Out-Null
+    }
+}
+
+# --- Preferences par profil utilisateur ---
+function Set-UserPreferences {
+    param([string]$BaseKey)
+
+    if ($Config.ApplyUserPreferenceTweaks) {
+        Invoke-Safely "Explorer opens to This PC ($BaseKey)" {
+            New-ItemProperty -Path "$BaseKey\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name LaunchTo -PropertyType DWord -Value 1 -Force | Out-Null
+        }
+        Invoke-Safely "Enable End Task from taskbar ($BaseKey)" {
+            New-ItemProperty -Path "$BaseKey\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\TaskbarDeveloperSettings" -Name TaskbarEndTask -PropertyType DWord -Value 1 -Force | Out-Null
+        }
+        Invoke-Safely "Restore full right-click context menu ($BaseKey)" {
+            New-Item -Path "$BaseKey\SOFTWARE\CLASSES\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32" -Force | Out-Null
+        }
+        Invoke-Safely "Speed up menu show delay ($BaseKey)" {
+            New-ItemProperty -Path "$BaseKey\Control Panel\Desktop" -Name MenuShowDelay -PropertyType String -Value '10' -Force | Out-Null
+        }
+    }
+
+    if ($Config.DisableConsumerFeatures) {
+        Invoke-Safely "Disable Start/Explorer ads and suggestions ($BaseKey)" {
+            New-ItemProperty -Path "$BaseKey\SOFTWARE\Microsoft\Windows\CurrentVersion\Search" -Name BingSearchEnabled -PropertyType DWord -Value 0 -Force | Out-Null
+            New-ItemProperty -Path "$BaseKey\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" -Name ContentDeliveryAllowed -PropertyType DWord -Value 0 -Force | Out-Null
+            New-ItemProperty -Path "$BaseKey\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" -Name 'SubscribedContent-338388Enabled' -PropertyType DWord -Value 0 -Force | Out-Null
+            New-ItemProperty -Path "$BaseKey\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name ShowCopilotButton -PropertyType DWord -Value 0 -Force | Out-Null
+        }
+    }
+}
+
+if ($Config.ApplyUserPreferenceTweaks -or $Config.DisableConsumerFeatures) {
+
+    $loadedSids = Get-ChildItem Registry::HKEY_USERS -ErrorAction SilentlyContinue |
+        Where-Object { $_.PSChildName -match '^S-1-5-21-\d+-\d+-\d+-\d+$' } |
+        Select-Object -ExpandProperty PSChildName
+
+    foreach ($sid in $loadedSids) {
+        Set-UserPreferences -BaseKey "Registry::HKEY_USERS\$sid"
+    }
+
+    if (Test-Path 'Registry::HKEY_USERS\TempHive') {
+        Invoke-Safely "Clean up leftover TempHive from a previous run" { reg unload 'HKU\TempHive' | Out-Null }
+    }
+
+    $profiles = Get-CimInstance Win32_UserProfile -ErrorAction SilentlyContinue |
+        Where-Object { -not $_.Special -and $_.SID -notin $loadedSids }
+
+    foreach ($profile in $profiles) {
+        $hivePath = Join-Path $profile.LocalPath 'NTUSER.DAT'
+        if (-not (Test-Path $hivePath)) { continue }
+        $loadResult = reg load 'HKU\TempHive' "$hivePath" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Log "SKIPPED: could not load hive for $($profile.LocalPath) -- $loadResult"
+            continue
+        }
+        Set-UserPreferences -BaseKey 'Registry::HKEY_USERS\TempHive'
+        # Force la liberation des handles .NET avant unload, sinon "Access is denied" intermittent.
+        [gc]::Collect()
+        [gc]::WaitForPendingFinalizers()
+        reg unload 'HKU\TempHive' | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Log "WARNING: could not unload hive for $($profile.LocalPath) -- may still be mounted"
+        }
+    }
+
+    $defaultHive = 'C:\Users\Default\NTUSER.DAT'
+    if (Test-Path $defaultHive) {
+        reg load 'HKU\DefaultHive' $defaultHive | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Set-UserPreferences -BaseKey 'Registry::HKEY_USERS\DefaultHive'
+            [gc]::Collect()
+            [gc]::WaitForPendingFinalizers()
+            reg unload 'HKU\DefaultHive' | Out-Null
+        } else {
+            Write-Log "SKIPPED: could not load Default profile hive"
+        }
+    }
+}
+
+# --- Marqueur de conformite + flag de reboot (pas de reboot force) ---
+New-Item -Path $MarkerPath -Force | Out-Null
+Set-ItemProperty -Path $MarkerPath -Name AppliedVersion -Value $ScriptVersion -Force
+Set-ItemProperty -Path $MarkerPath -Name LastRun -Value (Get-Date -Format 'yyyy-MM-dd HH:mm:ss') -Force
+Set-ItemProperty -Path $MarkerPath -Name PendingReboot -Value ([int]$RebootRequired) -Force
+
+Write-Log "=== Remediation finished. PendingReboot=$RebootRequired ==="
+Write-Output "Remediation applied (v$ScriptVersion). Reboot required: $RebootRequired. Log: $LogFile"
+exit 0

--- a/Intune/Remediation.ps1
+++ b/Intune/Remediation.ps1
@@ -9,7 +9,7 @@ Intune : configurer "Run this script using the logged-on credentials" = No (exec
 "Enforce script signature check" selon ta politique, 64-bit PowerShell = Yes.
 #>
 
-$ScriptVersion = '1.1.0'
+$ScriptVersion = '1.2.0'
 $MarkerPath    = 'HKLM:\SOFTWARE\TBOK-Optimizer'
 $LogDir        = "$env:ProgramData\TBOK-Optimizer"
 $LogFile       = Join-Path $LogDir 'remediation.log'
@@ -151,39 +151,59 @@ if ($Config.ApplyPerformanceTweaks) {
     }
 
     # Set-CimInstance sur Win32_PageFileSetting renvoie "Valeur hors de la plage" sur pas mal de
-    # builds (round-trip de proprietes read-only cote provider). Get-WmiObject/.Put() est le
-    # contournement documente et fiable pour cette classe WMI precise.
-    Invoke-Safely "Configure pagefile sizing" {
-        $ramMB = [Math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1MB, 0)
-        if ($ramMB -ge 32768) {
+    # builds (round-trip de proprietes read-only cote provider). Get-WmiObject/.Put() evite le
+    # faux succes (l'exception devient catchable), mais peut encore echouer sur certaines
+    # machines si InitialSize et MaximumSize sont pousses dans le meme .Put() - certains
+    # providers WMI valident les deux valeurs contre un etat pas encore rafraichi. On les
+    # pousse donc en 2 appels separes (contournement documente), avec un log de l'etat courant
+    # a chaque etape pour pouvoir diagnostiquer precisement laquelle echoue si ca persiste.
+    $ramMB = [Math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1MB, 0)
+    if ($ramMB -ge 32768) {
+        Invoke-Safely "Set pagefile management to automatic (RAM=$ramMB MB >= 32GB)" {
             $cs = Get-WmiObject Win32_ComputerSystem
             if (-not $cs.AutomaticManagedPagefile) {
                 $cs.AutomaticManagedPagefile = $true
                 $cs.Put() | Out-Null
                 $script:RebootRequired = $true
             }
-            Write-Log "RAM=$ramMB MB >= 32GB, pagefile management set to automatic"
-        } else {
-            $min = 4096
-            $max = if ($ramMB -lt 8192) { 8192 } elseif ($ramMB -lt 16384) { 16384 } else { 24576 }
+        }
+    } else {
+        $min = 4096
+        $max = if ($ramMB -lt 8192) { 8192 } elseif ($ramMB -lt 16384) { 16384 } else { 24576 }
+        Write-Log "Pagefile target: RAM=$ramMB MB, Initial=$min MB Maximum=$max MB"
+
+        Invoke-Safely "Disable automatic pagefile management" {
             $cs = Get-WmiObject Win32_ComputerSystem
+            Write-Log "AutomaticManagedPagefile currently=$($cs.AutomaticManagedPagefile)"
             if ($cs.AutomaticManagedPagefile) {
                 $cs.AutomaticManagedPagefile = $false
                 $cs.Put() | Out-Null
             }
-            $pf = Get-WmiObject Win32_PageFileSetting -Filter "Name='C:\\pagefile.sys'"
-            if ($pf) {
-                if ($pf.InitialSize -ne $min -or $pf.MaximumSize -ne $max) {
+        }
+
+        $pf = Get-WmiObject Win32_PageFileSetting -Filter "Name='C:\\pagefile.sys'" -ErrorAction SilentlyContinue
+        if ($pf) {
+            Write-Log "Existing pagefile setting: Initial=$($pf.InitialSize) MB Maximum=$($pf.MaximumSize) MB"
+            if ($pf.InitialSize -ne $min) {
+                Invoke-Safely "Set pagefile InitialSize to $min MB" {
                     $pf.InitialSize = $min
+                    $pf.Put() | Out-Null
+                    $script:RebootRequired = $true
+                }
+            }
+            $pf = Get-WmiObject Win32_PageFileSetting -Filter "Name='C:\\pagefile.sys'" -ErrorAction SilentlyContinue
+            if ($pf -and $pf.MaximumSize -ne $max) {
+                Invoke-Safely "Set pagefile MaximumSize to $max MB" {
                     $pf.MaximumSize = $max
                     $pf.Put() | Out-Null
                     $script:RebootRequired = $true
                 }
-            } else {
+            }
+        } else {
+            Invoke-Safely "Create pagefile setting (Initial=$min MB Maximum=$max MB)" {
                 Set-WmiInstance -Class Win32_PageFileSetting -Arguments @{ Name = 'C:\pagefile.sys'; InitialSize = $min; MaximumSize = $max } | Out-Null
                 $script:RebootRequired = $true
             }
-            Write-Log "RAM=$ramMB MB, pagefile Initial=$min MB Maximum=$max MB"
         }
     }
 }
@@ -214,24 +234,24 @@ if ($Config.ApplyServiceStartupTweaks) {
     # NlaSvc, netprofm, TokenBroker, UsoSvc, WpnService, RemoteAccess, RemoteRegistry (sensibles entreprise).
     $manualServices = @(
         'ALG', 'AppIDSvc', 'AppMgmt', 'AppReadiness', 'Appinfo', 'AssignedAccessManagerSvc', 'AxInstSV', 'BDESVC',
-        'BcastDVRUserService_*', 'BluetoothUserService_*', 'BTAGService', 'bthserv', 'CaptureService_*', 'cbdhsvc_*',
-        'CertPropSvc', 'cloudidsvc', 'COMSysApp', 'ClipSVC', 'ConsentUxUserSvc_*', 'CredentialEnrollmentManagerUserSvc_*',
-        'CscService', 'DcpSvc', 'dcsvc', 'defragsvc', 'DevQueryBroker', 'DeviceAssociationBroker_*', 'DeviceAssociationService',
-        'DeviceInstall', 'DevicePickerUserSvc_*', 'DevicesFlowUserSvc_*', 'diagnosticshub.standardcollector.service',
+        'BcastDVRUserService', 'BluetoothUserService', 'BTAGService', 'bthserv', 'CaptureService', 'cbdhsvc',
+        'CertPropSvc', 'cloudidsvc', 'COMSysApp', 'ClipSVC', 'ConsentUxUserSvc', 'CredentialEnrollmentManagerUserSvc',
+        'CscService', 'DcpSvc', 'dcsvc', 'defragsvc', 'DevQueryBroker', 'DeviceAssociationBroker', 'DeviceAssociationService',
+        'DeviceInstall', 'DevicePickerUserSvc', 'DevicesFlowUserSvc', 'diagnosticshub.standardcollector.service',
         'diagsvc', 'DisplayEnhancementService', 'DmEnrollmentSvc', 'dmwappushservice', 'dot3svc', 'DoSvc', 'embeddedmode',
         'fdPHost', 'fhsvc', 'hidserv', 'icssvc', 'EapHost', 'edgeupdate', 'edgeupdatem', 'EFS', 'EntAppSvc', 'FDResPub', 'Fax',
         'FrameServer', 'FrameServerMonitor', 'GraphicsPerfSvc', 'HvHost', 'IEEtwCollectorService', 'IKEEXT', 'IpxlatCfgSvc',
-        'lfsvc', 'lltdsvc', 'lmhosts', 'LxpSvc', 'McpManagementService', 'MessagingService_*', 'MicrosoftEdgeElevationService',
-        'MixedRealityOpenXRSvc', 'MSDTC', 'MsKeyboardFilter', 'MSiSCSI', 'msiserver', 'NPSMSvc_*', 'NaturalAuthentication',
+        'lfsvc', 'lltdsvc', 'lmhosts', 'LxpSvc', 'McpManagementService', 'MessagingService', 'MicrosoftEdgeElevationService',
+        'MixedRealityOpenXRSvc', 'MSDTC', 'MsKeyboardFilter', 'MSiSCSI', 'msiserver', 'NPSMSvc', 'NaturalAuthentication',
         'NcaSvc', 'NcbService', 'NcdAutoSetup', 'NetSetupSvc', 'Netman', 'NgcCtnrSvc', 'NgcSvc', 'p2pimsvc', 'p2psvc',
-        'P9RdrService_*', 'PcaSvc', 'PeerDistSvc', 'PenService_*', 'perceptionsimulation', 'PerfHost', 'PhoneSvc',
-        'PimIndexMaintenanceSvc_*', 'pla', 'PlugPlay', 'PNRPAutoReg', 'PNRPsvc', 'PolicyAgent', 'PrintNotify',
-        'PrintWorkflowUserSvc_*', 'PushToInstall', 'QWAVE', 'RasAuto', 'RasMan', 'RetailDemo', 'RmSvc', 'RpcLocator',
+        'P9RdrService', 'PcaSvc', 'PeerDistSvc', 'PenService', 'perceptionsimulation', 'PerfHost', 'PhoneSvc',
+        'PimIndexMaintenanceSvc', 'pla', 'PlugPlay', 'PNRPAutoReg', 'PNRPsvc', 'PolicyAgent', 'PrintNotify',
+        'PrintWorkflowUserSvc', 'PushToInstall', 'QWAVE', 'RasAuto', 'RasMan', 'RetailDemo', 'RmSvc', 'RpcLocator',
         'SCPolicySvc', 'ScDeviceEnum', 'SCardSvr', 'SDRSVC', 'seclogon', 'SEMgrSvc', 'SensorDataService', 'SensorService',
         'SensrSvc', 'SessionEnv', 'SharedAccess', 'SharedRealitySvc', 'shpamsvc', 'SmsRouter', 'smphost', 'SNMPTrap',
         'spectrum', 'SstpSvc', 'SSDPSRV', 'StiSvc', 'StorSvc', 'svsvc', 'swprv', 'TabletInputService', 'TapiSrv',
-        'TieringEngineService', 'TimeBroker', 'TimeBrokerSvc', 'TroubleshootingSvc', 'UI0Detect', 'UdkUserSvc_*',
-        'UmRdpService', 'UnistoreSvc_*', 'UserDataSvc_*', 'upnphost', 'VacSvc', 'vds', 'vmicguestinterface', 'vmicheartbeat',
+        'TieringEngineService', 'TimeBroker', 'TimeBrokerSvc', 'TroubleshootingSvc', 'UI0Detect', 'UdkUserSvc',
+        'UmRdpService', 'UnistoreSvc', 'UserDataSvc', 'upnphost', 'VacSvc', 'vds', 'vmicguestinterface', 'vmicheartbeat',
         'vmickvpexchange', 'vmicrdv', 'vmicshutdown', 'vmictimesync', 'vmicvmsession', 'vmicvss', 'VSS', 'WalletService',
         'wbengine', 'WcsPlugInService', 'wcncsvc', 'WdNisSvc', 'WdiServiceHost', 'WdiSystemHost', 'WebClient', 'Wecsvc',
         'wercplsupport', 'WEPHOSTSVC', 'WerSvc', 'WFDSConMgrSvc', 'WiaRpc', 'WinHttpAutoProxySvc', 'WinRM', 'wisvc',
@@ -241,12 +261,12 @@ if ($Config.ApplyServiceStartupTweaks) {
     foreach ($s in $manualServices) { Set-ServiceStartupSafely -Name $s -StartupType Manual }
 
     $autoServices = @(
-        'AudioEndpointBuilder', 'AudioSrv', 'BFE', 'BITS', 'BrokerInfrastructure', 'BthHFSrv', 'CDPUserSvc_*',
+        'AudioEndpointBuilder', 'AudioSrv', 'BFE', 'BITS', 'BrokerInfrastructure', 'BthHFSrv', 'CDPUserSvc',
         'CoreMessagingRegistrar', 'CryptSvc', 'DPS', 'DcomLaunch', 'Dhcp', 'DispBrokerDesktopSvc', 'Dnscache', 'dusmsvc',
         'EventLog', 'EventSystem', 'FontCache', 'gpsvc', 'iphlpsvc', 'LSM', 'LanmanServer', 'LanmanWorkstation', 'MpsSvc',
-        'nsi', 'OneSyncSvc_*', 'Power', 'ProfSvc', 'RpcEptMapper', 'RpcSs', 'SENS', 'SamSs', 'Schedule', 'ShellHWDetection',
+        'nsi', 'OneSyncSvc', 'Power', 'ProfSvc', 'RpcEptMapper', 'RpcSs', 'SENS', 'SamSs', 'Schedule', 'ShellHWDetection',
         'Spooler', 'sppsvc', 'SystemEventsBroker', 'Themes', 'tiledatamodelsvc', 'TrkWks', 'tzautoupdate', 'uhssvc',
-        'UserManager', 'W32Time', 'Wcmsvc', 'WinDefend', 'Winmgmt', 'WlanSvc', 'WpnUserService_*'
+        'UserManager', 'W32Time', 'Wcmsvc', 'WinDefend', 'Winmgmt', 'WlanSvc', 'WpnUserService'
     )
     foreach ($s in $autoServices) { Set-ServiceStartupSafely -Name $s -StartupType Automatic }
 

--- a/Intune/Remediation.ps1
+++ b/Intune/Remediation.ps1
@@ -360,7 +360,7 @@ function Set-UserPreferences {
 if ($Config.ApplyUserPreferenceTweaks -or $Config.DisableConsumerFeatures) {
 
     $loadedSids = Get-ChildItem Registry::HKEY_USERS -ErrorAction SilentlyContinue |
-        Where-Object { $_.PSChildName -match '^S-1-5-21-\d+-\d+-\d+-\d+$' } |
+        Where-Object { $_.PSChildName -match '^S-1-5-21-|^S-1-12-1-' } |
         Select-Object -ExpandProperty PSChildName
 
     foreach ($sid in $loadedSids) {

--- a/TBOKwinOptimizer.bat
+++ b/TBOKwinOptimizer.bat
@@ -283,30 +283,30 @@ call :SetServiceStartup Appinfo demand
 call :SetServiceStartup AssignedAccessManagerSvc demand
 call :SetServiceStartup AxInstSV demand
 call :SetServiceStartup BDESVC demand
-call :SetServiceStartup  BcastDVRUserService_* demand
-call :SetServiceStartup  BluetoothUserService_* demand
+call :SetServiceStartup  BcastDVRUserService demand
+call :SetServiceStartup  BluetoothUserService demand
 ::deprecated call :SetServiceStartup 'Browser' demand
 call :SetServiceStartup BTAGService demand
 call :SetServiceStartup bthserv demand
-call :SetServiceStartup  CaptureService_* demand
-call :SetServiceStartup  cbdhsvc_* demand
+call :SetServiceStartup  CaptureService demand
+call :SetServiceStartup  cbdhsvc demand
 ::deprecated call :SetServiceStartup CDPSvc demand
 call :SetServiceStartup CertPropSvc demand
 call :SetServiceStartup cloudidsvc demand
 call :SetServiceStartup COMSysApp demand
 call :SetServiceStartup  ClipSVC demand
-call :SetServiceStartup  ConsentUxUserSvc_* demand
-call :SetServiceStartup  CredentialEnrollmentManagerUserSvc_* demand
+call :SetServiceStartup  ConsentUxUserSvc demand
+call :SetServiceStartup  CredentialEnrollmentManagerUserSvc demand
 call :SetServiceStartup CscService demand
 call :SetServiceStartup  DcpSvc demand
 call :SetServiceStartup dcsvc demand
 call :SetServiceStartup defragsvc demand
 call :SetServiceStartup DevQueryBroker demand
-call :SetServiceStartup  DeviceAssociationBroker_* demand
+call :SetServiceStartup  DeviceAssociationBroker demand
 call :SetServiceStartup DeviceAssociationService demand
 call :SetServiceStartup DeviceInstall demand
-call :SetServiceStartup  DevicePickerUserSvc_* demand
-call :SetServiceStartup  DevicesFlowUserSvc_* demand
+call :SetServiceStartup  DevicePickerUserSvc demand
+call :SetServiceStartup  DevicesFlowUserSvc demand
 call :SetServiceStartup  diagnosticshub.standardcollector.service demand
 call :SetServiceStartup diagsvc demand
 call :SetServiceStartup DisplayEnhancementService demand
@@ -342,14 +342,14 @@ call :SetServiceStartup lltdsvc demand
 call :SetServiceStartup lmhosts demand
 call :SetServiceStartup LxpSvc demand
 call :SetServiceStartup McpManagementService demand
-call :SetServiceStartup  MessagingService_* demand
+call :SetServiceStartup  MessagingService demand
 call :SetServiceStartup MicrosoftEdgeElevationService demand
 call :SetServiceStartup  MixedRealityOpenXRSvc demand
 call :SetServiceStartup MSDTC demand
 call :SetServiceStartup MsKeyboardFilter demand
 call :SetServiceStartup MSiSCSI demand
 call :SetServiceStartup  msiserver demand
-call :SetServiceStartup  NPSMSvc_* demand
+call :SetServiceStartup  NPSMSvc demand
 call :SetServiceStartup NaturalAuthentication demand
 call :SetServiceStartup NcaSvc demand
 call :SetServiceStartup NcbService demand
@@ -362,21 +362,21 @@ call :SetServiceStartup  NgcSvc demand
 ::omitforENTERPRISE call :SetServiceStartup netprofm demand
 call :SetServiceStartup  p2pimsvc demand
 call :SetServiceStartup  p2psvc demand
-call :SetServiceStartup  P9RdrService_* demand
+call :SetServiceStartup  P9RdrService demand
 call :SetServiceStartup PcaSvc demand
 call :SetServiceStartup PeerDistSvc demand
-call :SetServiceStartup  PenService_* demand
+call :SetServiceStartup  PenService demand
 call :SetServiceStartup perceptionsimulation demand
 call :SetServiceStartup PerfHost demand
 call :SetServiceStartup PhoneSvc demand
-call :SetServiceStartup  PimIndexMaintenanceSvc_* demand
+call :SetServiceStartup  PimIndexMaintenanceSvc demand
 call :SetServiceStartup pla demand
 call :SetServiceStartup PlugPlay demand
 call :SetServiceStartup  PNRPAutoReg demand
 call :SetServiceStartup  PNRPsvc demand
 call :SetServiceStartup PolicyAgent demand
 call :SetServiceStartup PrintNotify demand
-call :SetServiceStartup  PrintWorkflowUserSvc_* demand
+call :SetServiceStartup  PrintWorkflowUserSvc demand
 call :SetServiceStartup PushToInstall demand
 call :SetServiceStartup QWAVE demand
 call :SetServiceStartup RasAuto demand
@@ -416,10 +416,10 @@ call :SetServiceStartup  TimeBrokerSvc demand
 ::omitforENTERPRISE call :SetServiceStartup TokenBroker demand
 call :SetServiceStartup TroubleshootingSvc demand
 call :SetServiceStartup  UI0Detect demand
-call :SetServiceStartup  UdkUserSvc_* demand
+call :SetServiceStartup  UdkUserSvc demand
 call :SetServiceStartup UmRdpService demand
-call :SetServiceStartup  UnistoreSvc_* demand
-call :SetServiceStartup  UserDataSvc_* demand
+call :SetServiceStartup  UnistoreSvc demand
+call :SetServiceStartup  UserDataSvc demand
 ::omitforENTERPRISE call :SetServiceStartup UsoSvc demand
 call :SetServiceStartup upnphost demand
 call :SetServiceStartup  VacSvc demand
@@ -474,7 +474,7 @@ call :SetServiceStartup BFE auto
 call :SetServiceStartup BITS auto
 call :SetServiceStartup BrokerInfrastructure auto
 call :SetServiceStartup BthHFSrv auto
-call :SetServiceStartup CDPUserSvc_* auto
+call :SetServiceStartup CDPUserSvc auto
 call :SetServiceStartup CoreMessagingRegistrar auto
 call :SetServiceStartup CryptSvc auto
 call :SetServiceStartup DPS auto
@@ -493,7 +493,7 @@ call :SetServiceStartup LanmanServer auto
 call :SetServiceStartup LanmanWorkstation auto
 call :SetServiceStartup MpsSvc auto
 call :SetServiceStartup nsi auto
-call :SetServiceStartup OneSyncSvc_* auto
+call :SetServiceStartup OneSyncSvc auto
 call :SetServiceStartup Power auto
 call :SetServiceStartup ProfSvc auto
 call :SetServiceStartup RpcEptMapper auto
@@ -518,7 +518,7 @@ call :SetServiceStartup Wcmsvc auto
 call :SetServiceStartup WinDefend auto
 call :SetServiceStartup Winmgmt auto
 call :SetServiceStartup WlanSvc auto
-call :SetServiceStartup WpnUserService_* auto
+call :SetServiceStartup WpnUserService auto
 ECHO.
 Call :LOG Changing less essential services to delayed-auto
 ::omit call :SetServiceStartup MapsBroker delayed-auto

--- a/TBOKwinOptimizer.bat
+++ b/TBOKwinOptimizer.bat
@@ -150,7 +150,8 @@ call :LOG Should be disabled for desktops-especially with SSD or NVME
 		powercfg -h off
 		goto f8startup
 	:unknownchassis
-	call :LOG Unable to determine chassis type. Hibernation was not changed.
+	for /f "delims=" %%R in ('%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -Command "(Get-CimInstance -Query 'Select * From CIM_Chassis').ChassisTypes -join ','" 2^>NUL') do set "RawChassisType=%%R"
+	call :LOG Unable to determine chassis type (raw ChassisTypes=!RawChassisType!). Hibernation was not changed.
 	
 	
 :F8startup
@@ -172,7 +173,8 @@ powershell.exe -NoProfile -Command ^
     $ramMB = [Math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1MB, 0); ^
     Write-Output ('Detected RAM: ' + $ramMB + ' MB'); ^
     if ($ramMB -ge 32768) { ^
-        Set-CimInstance -Query 'SELECT * FROM Win32_ComputerSystem' -Property @{AutomaticManagedPageFile=$true} ^| Out-Null; ^
+        $cs = Get-WmiObject Win32_ComputerSystem; ^
+        if (-not $cs.AutomaticManagedPagefile) { $cs.AutomaticManagedPagefile = $true; $cs.Put() ^| Out-Null }; ^
         Write-Output 'Configured Windows automatic pagefile management.'; ^
         exit 0; ^
     }; ^
@@ -182,16 +184,17 @@ powershell.exe -NoProfile -Command ^
         {$_ -lt 16384} { $max = [uint32]16384; break }; ^
         default { $max = [uint32]24576 } ^
     }; ^
-    Set-CimInstance -Query 'SELECT * FROM Win32_ComputerSystem' -Property @{AutomaticManagedPageFile=$false} ^| Out-Null; ^
-    $pf = Get-CimInstance Win32_PageFileSetting -Filter 'Name=''C:\\pagefile.sys'''; ^
+    $cs = Get-WmiObject Win32_ComputerSystem; ^
+    if ($cs.AutomaticManagedPagefile) { $cs.AutomaticManagedPagefile = $false; $cs.Put() ^| Out-Null }; ^
+    $pf = Get-WmiObject Win32_PageFileSetting -Filter 'Name=''C:\\pagefile.sys'''; ^
     if ($pf) { ^
         if (($pf.InitialSize -eq $min) -and ($pf.MaximumSize -eq $max)) { ^
             Write-Output ('Already configured. Min=' + $min + ' MB Max=' + $max + ' MB'); ^
             exit 0; ^
         }; ^
-        Set-CimInstance -InputObject $pf -Property @{InitialSize=$min; MaximumSize=$max} ^| Out-Null; ^
+        $pf.InitialSize = $min; $pf.MaximumSize = $max; $pf.Put() ^| Out-Null; ^
     } else { ^
-        New-CimInstance -ClassName Win32_PageFileSetting -Property @{Name='C:\pagefile.sys'; InitialSize=$min; MaximumSize=$max} ^| Out-Null; ^
+        Set-WmiInstance -Class Win32_PageFileSetting -Arguments @{Name='C:\pagefile.sys'; InitialSize=$min; MaximumSize=$max} ^| Out-Null; ^
     }; ^
     Write-Output ('Configured pagefile: Initial=' + $min + ' MB Maximum=' + $max + ' MB'); ^
     Write-Output 'Reboot required for changes to take effect.'; ^

--- a/TBOKwinOptimizer.bat
+++ b/TBOKwinOptimizer.bat
@@ -949,7 +949,7 @@ call :LOG Starting per-user registry deployment...
 :: 1. CURRENTLY LOADED USERS
 :: ================================
 call :Log Processing loaded user hives
-for /f "delims=" %%U in ('reg query HKEY_USERS ^| findstr /R "HKEY_USERS\\S-1-5-21-"') do (
+for /f "delims=" %%U in ('reg query HKEY_USERS ^| findstr /R "HKEY_USERS\\S-1-5-21- HKEY_USERS\\S-1-12-1-"') do (
 ::echo Found User Hive: [%%U]
 call :ApplySettings "%%U"
 )


### PR DESCRIPTION
## What's in here

**1. Bugfix: pagefile sizing silently fails on some builds**

`Set-CimInstance` against `Win32_PageFileSetting` / `Win32_ComputerSystem` throws a
`Value out of range` error on a number of builds (a known CIM provider quirk with that
WMI class - the modify-instance path round-trips read-only properties). Because it's a
non-terminating error, the script's `try/catch` never catches it, so it logs
`Configured pagefile: Initial=... Maximum=...` as if it succeeded even when the write
was rejected and nothing actually changed. Ran into this myself on a real machine
(16 GB RAM, Windows 11) - `Detected RAM: 16378 MB` then the CIM error, followed
immediately by the false "Configured pagefile" success line.

Fix: use the `Get-WmiObject`/`.Put()` path instead of `Set-CimInstance`/`New-CimInstance`
for both `Win32_ComputerSystem.AutomaticManagedPagefile` and `Win32_PageFileSetting`.
This is the documented workaround for this specific WMI class, and it raises catchable
exceptions on real failures instead of swallowing them.

**2. Small diagnostic improvement: chassis detection**

When chassis type detection falls through to `:unknownchassis`, it now logs the raw
`ChassisTypes` value(s) it saw, e.g. `raw ChassisTypes=13`. Behavior is unchanged
(hibernation is still left untouched when the type can't be mapped) - this just makes it
possible to tell, from the log, whether a given fleet's hardware reports a chassis type
outside the current Desktop/Laptop lists.

**3. New, optional: `Intune/` - Proactive Remediation scripts for fleet deployment**

Added `Detection.ps1` + `Remediation.ps1` (+ a README) as a separate, additive path for
running a safe subset of these tweaks unattended across a managed fleet via Microsoft
Intune Proactive Remediations, since the `.bat` script's UAC self-elevation, `CHOICE`
menu and reboot prompt only make sense interactively on one PC. It does not change
anything about the existing `.bat` script or its behavior. Defaults are intentionally
conservative for a business fleet (see `Intune/README.md` for the reasoning):

- Telemetry is split into individual toggles instead of one on/off switch - purely
  cosmetic ones (feedback popups, advertising ID, Recall, limiting enhanced diagnostic
  data) on by default, anything that could affect Defender for Endpoint / Update
  Compliance reporting (telemetry level, DiagTrack service, WER, Delivery Optimization)
  off by default.
- No forced reboot - writes a `PendingReboot` registry flag instead of prompting, so it
  doesn't reboot unattended machines mid-workday.
- No Windows Copilot removal (out of scope for orgs on Microsoft 365 Copilot, and not
  something every org will want touched centrally).

Happy to adjust scope/naming/defaults if you'd rather structure this differently -
opened as a starting point since it seemed like a natural companion to the existing
"safe for business use" positioning of the repo.